### PR TITLE
Add shadow packages, that point to the correct names

### DIFF
--- a/packages/autogrammarjs/README.md
+++ b/packages/autogrammarjs/README.md
@@ -1,0 +1,1 @@
+[This package has been renamed to `autogrammer`](https://www.npmjs.com/package/autogrammer).

--- a/packages/autogrammarjs/package.json
+++ b/packages/autogrammarjs/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "autogrammar",
+  "author": "Kevin Scott",
+  "dependencies": {
+    "autogrammer": "latest"
+  }
+}

--- a/packages/autogrammarpy/MANIFEST.in
+++ b/packages/autogrammarpy/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/packages/autogrammarpy/README.md
+++ b/packages/autogrammarpy/README.md
@@ -1,0 +1,1 @@
+[This package has been renamed to `autogrammer`](https://pypi.org/project/autogrammer/).

--- a/packages/autogrammarpy/pyproject.toml
+++ b/packages/autogrammarpy/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "autogrammar"
+version = "0.0.1"
+# Notes
+authors = [{ name = "Kevin Scott", email = "kevin@autogrammer.dev" }]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+]
+classifiers = [
+]
+

--- a/packages/autogrammerjs/README.md
+++ b/packages/autogrammerjs/README.md
@@ -7,36 +7,4 @@
 <a href="https://codecov.io/gh/thekevinscott/autogrammer"><img alt="Code Coverage for Autogrammer" src="https://img.shields.io/codecov/c/github/thekevinscott/autogrammer" /></a>
 <a href="https://deepsource.io/gh/thekevinscott/autogrammer/?ref=repository-badge"><img alt="DeepSource issues for Autogrammer" src="https://deepsource.io/gh/thekevinscott/autogrammer.svg/?label=active+issues&show_trend=true" /></a>
 
-Autogrammer is a JS library for generating syntactically valid code from an LLM. It achieves this by leveraging grammars to restrain LLM tokens.
-
-## Quickstart
-
-```javascript
-const synth = new Autogrammer({
-  language: 'json', // specify the language
-  model: { // specify the model backend
-    protocol: 'llama.cpp',
-    endpoint: '/some/path/to/llama.cpp/server',
-  }
-});
-const result = await synth.synthesize(prompt, {
-  n: 100, // max number of tokens
-  stream: true, // whether to stream or not
-  streamCallback: ({ chunk, partial }) => {
-    console.log(partial) // if streaming, the partially created string output
-    console.log(chunk) // the full chunk output from the LLM
-  }
-});
-```
-
-## Supported Languages
-
-- JSON
-
-Support is planned for SQL, Python, and Javascript.
-
-## Supported LLMs
-
-Currently the following LLM frameworks are supported:
-
-- llama.cpp
+Autogrammer is a Python library for generating syntactically valid code from an LLM. It achieves this by leveraging grammars to restrain LLM tokens.


### PR DESCRIPTION
To prevent name squatting and collisions 